### PR TITLE
Configure navigation with Prologue theme

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: About
+permalink: /about/
+icon: fa-user
+order: 1
+---
+This page provides information about me.
+

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -11,3 +11,13 @@ h2 { font-size: 22px; }
 h3 { font-size: 18px; }
 h4 { font-size: 16px; }
 
+
+#header .image.avatar {
+  margin-right: 0.75rem; /* adjust spacing */
+}
+
+a .icon,
+a svg,
+a .emoji {
+  margin-right: 0.25rem;
+}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: home
 title: Krishnakumar's Personal Portfolio
+hide: true
 ---
 
 <section id="about" class="main style1">

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Projects
+permalink: /projects/
+icon: fa-folder-open
+order: 2
+---
+Details about my projects.
+


### PR DESCRIPTION
## Summary
- hide homepage from sidebar navigation
- add icons and ordering for About and Projects pages
- drop unused menu configuration to rely on theme defaults

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68ae29bded808322b906687b7bec95e9